### PR TITLE
0.4.0 - New patterns lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ _content.md
 dist
 *.egg-info
 venv
+*.pyc
+__pycache__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] - 2024-12-22
+
+- Add: Pattern Matcher for more complex file matching, now you can use `.gitignore` like syntax.
+- Enhanced: `--pattern` option now supports `.gitignore` like syntax.
+- Enhanced: code refactoring and cleanup.
+
 ## [0.3.7] - 2024-11-16
 
 - Add: `--profile` option to add global rules

--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ It is very powerful and flexible, with support for:
 
 Configuration can be keept in a `maid.json` file in the root directory of the project and even modified in subdirectories using a `maid.json` file that is only applied to that directory and its subdirectories.
 
+## BREAKING CHANGES
+
+### v0.4.0
+
+v0.4.0 introduces some breaking changes and new features:
+
+- Now `--blacklist` option has been replaced by `--pattern` option. The `--pattern` option can be used multiple times to specify multiple patterns to ignore.
+
+- Now the pattern format is the same as `.gitignore` patterns, so you can use `*` to match any sequence of characters, `?` to match any single character, and `**` to match any sequence of characters, including slashes.
+
+- Now patterns are matched against the full path of the file or directory, so you can use patterns like `**/__pycache__` to ignore all `__pycache__` directories in the project.
+
 ## Installation
 
 `maid` requires Python 3.6 or later.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The creation of special _rules_ helps developer to filter text files and remove 
 
 It is very powerful and flexible, with support for:
 
-- blacklisting files and directories
+- ignoring files and directories (with the same syntax as `.gitignore`)
 - filtering text files using special `rules` (see below)
 - logging
 
@@ -32,7 +32,7 @@ maid [OPTIONS] PATHS...
 
 - `-o`, `--output`: Specify the output Markdown file (default: `_content.md` in the current directory).
 - `--log`: Enable logging to stdout.
-- `--blacklist`: Glob patterns for files or directories to skip (matched against filename only). This option can be used multiple times.
+- `--pattern`: Glob ignoring patterns for files or directories to skip (matched against filename only). This option can be used multiple times.
 - `--maid-file`: File containing `maid` configuration (default: `maid.json` in the current directory).
 - `--verbose`: Display some extra information.
 - `--version`: Display the version.
@@ -59,17 +59,17 @@ To enable logging:
 ./maid -o output.md --log src
 ```
 
-### Using Blacklist Patterns
+### Using Ignoring Patterns
 
 To skip certain files or directories:
 
 ```bash
-./maid -o output.md --blacklist "*.log" --blacklist "__pycache__" src
+./maid -o output.md --pattern "*.log" --pattern "__pycache__" src
 ```
 
 ### Using a Maid configuration File
 
-To use a blacklist file:
+To use a custom maid configuration file:
 
 ```bash
 ./maid -o output.md --maid-file maid-special.json src
@@ -78,7 +78,7 @@ To use a blacklist file:
 ### Reading Global and Local maid.json Files
 
 Every directory scanned by `maid` will be checked for a `maid.json` file. If found, the patterns and rules in the file will be used to skip files or directories.
-Patterns are added to the current blacklist, so they can be combined with other blacklist patterns.
+Patterns are added to the current ignored patterns, so they can be combined with other ignoring patterns.
 
 At startup, `maid` will look for a global `maid.json` file in the following locations:
 
@@ -88,9 +88,9 @@ At startup, `maid` will look for a global `maid.json` file in the following loca
 - `.local/share/maid` directory in the home directory.
 - `.config/maid` directory in the home directory.
 
-### Blacklist Patterns
+### Ignoring Patterns
 
-Blacklist patterns can be specified directly via the `--blacklist` option or through a file using the `patterns` section in `--maid-file` option. Patterns are matched against filenames only.
+Ignoring patterns can be specified directly via the `--pattern` option or through a file using the `patterns` section in `--maid-file` option. Patterns match against filename and path, and they follow the same `.gitignore` syntax.
 
 ### Example `maid.json` File
 

--- a/lib/pattern_matcher.py
+++ b/lib/pattern_matcher.py
@@ -124,6 +124,18 @@ class PatternMatcher:
         self._patterns.extend(patterns)
         self._optimized = False
 
+    def clear_patterns(self) -> None:
+        """Clear all patterns from the matcher.
+
+        Examples:
+            >>> matcher = PatternMatcher(["*.py", "!test_*.py"])
+            >>> matcher.clear_patterns()
+            >>> matcher.patterns
+            []
+        """
+        self._patterns.clear()
+        self._optimized = False
+
     def matches(self, filepath: Union[str, Path]) -> bool:
         """Check if a filepath matches any of the patterns.
 

--- a/lib/pattern_matcher.py
+++ b/lib/pattern_matcher.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+
+# flake8: noqa: E203
+
+import re
+from pathlib import Path
+from typing import Union, Sequence
+
+
+class PatternMatcher:
+    """
+    A class to match file paths against a set of glob patterns and exclusion patterns.
+
+    This class allows you to add glob patterns and exclusion patterns to match file paths.
+    Patterns can be added individually or as a sequence. The class supports checking if
+    a given file path matches any of the added patterns.
+
+    Internal Attributes:
+        _patterns (list[str]): A list of patterns to match against.
+        _optimized (bool): A flag indicating whether the patterns have been optimized.
+
+    Public properties:
+        patterns (list[str]): A list of optimized patterns.
+
+    Internal Methods:
+        __init__(patterns: Sequence[str] = None):
+            Initialize a new PatternMatcher instance.
+        _ensure_optimized() -> None:
+            Ensure the patterns are optimized for matching.
+        _normalize_path(path: str) -> str:
+            Normalize a file path by stripping leading "./" or "/".
+        _convert_to_regex(pattern: str) -> str:
+            Convert a glob pattern to a regular expression.
+
+    Public Methods:
+        add_pattern(pattern: str) -> None:
+            Add a single pattern to the matcher.
+        add_patterns(patterns: Sequence[str]) -> None:
+            Add multiple patterns to the matcher.
+        matches(filepath: Union[str, Path]) -> bool:
+            Check if a filepath matches any of the patterns.
+    """
+
+    def __init__(self, patterns: Sequence[str] = None):
+        """Initialize a new PatternMatcher instance.
+
+        Args:
+            patterns (Sequence[str], optional): A sequence of patterns to add.
+                Each pattern can be a glob pattern or an exclusion pattern starting
+                with "!". Defaults to None.
+
+        Examples:
+            >>> matcher = PatternMatcher(["*.py", "!test_*.py"])
+        """
+        self._patterns: list[str] = []
+        self._optimized = False
+        if patterns:
+            self.add_patterns(patterns)
+
+    def _ensure_optimized(self) -> None:
+        if not self._optimized:
+            self._patterns.sort(key=lambda x: not x.startswith("!"))
+            self._patterns = [
+                f"{p}**" if p.endswith("/") else p
+                for p in dict.fromkeys(p.strip() for p in self._patterns)
+            ]
+            self._optimized = True
+
+    def _normalize_path(self, path: str) -> str:
+        path = path.strip()
+        return (
+            path[2:]
+            if path.startswith("./")
+            else path[1:] if path.startswith("/") else path
+        )
+
+    def _convert_to_regex(self, pattern: str) -> str:
+        parts = []
+        i = 0
+        while i < len(pattern):
+            if pattern[i] == "*":
+                parts.append(
+                    ".*" if i + 1 < len(pattern) and pattern[i + 1] == "*" else "[^/]*"
+                )
+                i += 1 + (pattern[i : i + 2] == "**")
+            elif pattern[i] == "?":
+                parts.append("[^/]")
+                i += 1
+            elif pattern[i] == "[":
+                j = pattern.find("]", i + 1)
+                parts.append(pattern[i : j + 1] if j != -1 else re.escape(pattern[i]))
+                i = j + 1 if j != -1 else i + 1
+            else:
+                parts.append(re.escape(pattern[i]))
+                i += 1
+        return f"^{''.join(parts)}$"
+
+    def add_pattern(self, pattern: str) -> None:
+        """Add a single pattern to the matcher.
+
+        Args:
+            pattern (str): The pattern to add. Can be a glob pattern (e.g. "*.py")
+                or an exclusion pattern starting with "!" (e.g. "!*.pyc").
+
+        Examples:
+            >>> matcher = PatternMatcher()
+            >>> matcher.add_pattern("*.py")
+            >>> matcher.add_pattern("!test_*.py")
+        """
+        self._patterns.append(pattern)
+        self._optimized = False
+
+    def add_patterns(self, patterns: Sequence[str]) -> None:
+        """Add multiple patterns to the matcher.
+
+        Args:
+            patterns (Sequence[str]): A sequence of patterns to add. Each pattern can be
+                a glob pattern or an exclusion pattern starting with "!".
+
+        Examples:
+            >>> matcher = PatternMatcher()
+            >>> matcher.add_patterns(["*.py", "!test_*.py", "src/**/*.py"])
+        """
+        self._patterns.extend(patterns)
+        self._optimized = False
+
+    def matches(self, filepath: Union[str, Path]) -> bool:
+        """Check if a filepath matches any of the patterns.
+
+        Args:
+            filepath (Union[str, Path]): The path to check against the patterns.
+                Can be either a string or a Path object.
+
+        Returns:
+            bool: True if the path matches any of the inclusion patterns and none
+                of the exclusion patterns, False otherwise.
+
+        Examples:
+            >>> matcher = PatternMatcher(["*.py", "!test_*.py"])
+            >>> matcher.matches("foo.py")
+            True
+            >>> matcher.matches("test_foo.py")
+            False
+        """
+        self._ensure_optimized()
+        filepath = self._normalize_path(str(filepath))
+
+        for pattern in self._patterns:
+            if not pattern or pattern.startswith("#"):
+                continue
+
+            is_negation = pattern.startswith("!")
+            pattern = self._normalize_path(pattern[1:] if is_negation else pattern)
+            regex = self._convert_to_regex(pattern)
+
+            path_parts = filepath.split("/")
+            if any(
+                re.match(regex, "/".join(path_parts[i:]))
+                for i in range(len(path_parts))
+            ):
+                return not is_negation
+
+        return False
+
+    @property
+    def patterns(self) -> list[str]:
+        self._ensure_optimized()
+        return self._patterns.copy()
+
+
+if __name__ == "__main__":
+    matcher = PatternMatcher(
+        [
+            "!important.pyc",
+            "./*.py",
+            "*.py[cod]",
+            "temp/",
+            "!./temp/important.txt",
+            "/root_only.txt",
+        ]
+    )
+
+    # Add new patterns
+    matcher.add_pattern("*.json")
+    matcher.add_patterns(["!test/*.log", "docs/"])
+
+    def test_file(filepath: str, expected_result: bool):
+        res = matcher.matches(filepath)
+
+        if res != expected_result:
+            print(f"Test failed for {filepath}: expected {expected_result}, got {res}")
+
+    test_file("./file.py", True)
+    test_file("./temp/test.txt", True)
+    test_file("temp/test.txt", True)
+    test_file("./temp/important.txt", False)
+    test_file("file.py", True)
+    test_file("temp/important.txt", False)
+    test_file("file.pyc", True)
+    test_file("important.pyc", False)
+    test_file("temp/file.txt", True)
+    test_file("root_only.txt", True)
+    test_file("important.json", True)
+    test_file("test/file.log", False)
+    test_file("docs/file.txt", True)
+
+    print(matcher.patterns)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="fsoft-maid",
-    version="0.3.7",
+    version="0.4.0",
     description="Markdown AI Doc creator",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
v0.4.0 introduces some breaking changes and new features:

- Now `--blacklist` option has been replaced by `--pattern` option. The `--pattern` option can be used multiple times to specify multiple patterns to ignore.

- Now the pattern format is the same as `.gitignore` patterns, so you can use `*` to match any sequence of characters, `?` to match any single character, and `**` to match any sequence of characters, including slashes.

- Now patterns are matched against the full path of the file or directory, so you can use patterns like `**/__pycache__` to ignore all `__pycache__` directories in the project.